### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Kotlin/Multiplatform wrapper for Bitcoin Core's secp256k1 library. Targets: JVM,
 
 ## Installation
 
-[ ![Download](https://api.bintray.com/packages/acinq/libs/secp256k1-kmp/images/download.svg) ](https://bintray.com/acinq/libs/secp256k1-kmp/)
+[ ![Download](https://api.bintray.com/packages/acinq/libs/secp256k1/images/download.svg) ](https://bintray.com/acinq/libs/secp256k1-kmp/)
 
 First, you need to add the ACINQ libraries repository:
 


### PR DESCRIPTION
The package in bintray has lost the `-kmp`.
The badge needs to be updated to avoid image not found.