### PR TITLE
Kotlin 1.4.31

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,35 @@ jobs:
           path: ~/.gradle
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
+      - name: Android environment
+        shell: bash
+        run: |
+          echo "ANDROID_HOME=$ANDROID_HOME" >> $GITHUB_ENV
+          echo "ANDROID_NDK_VERSION=21.3.6528147" >> $GITHUB_ENV
+      - name: Cached Android NDK
+        uses: actions/cache@v2
+        with:
+          path: ${{ format('{0}/ndk/{1}', env.ANDROID_HOME, env.ANDROID_NDK_VERSION) }}
+          key: ${{ runner.os }}-android-ndk-${{ env.ANDROID_NDK_VERSION }}
+      - name: Set up shell
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          rm.exe "C:/WINDOWS/system32/bash.EXE"
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Setup Android
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: |
+          $ANDROID_HOME/tools/bin/sdkmanager "ndk;$ANDROID_NDK_VERSION"
+      - name: Setup Android
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          $ANDROID_HOME\\tools\\bin\\sdkmanager.bat "ndk;$ANDROID_NDK_VERSION"
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
@@ -35,11 +64,6 @@ jobs:
       - name: Install Automake
         if: matrix.os == 'macOS-latest'
         run: brew install automake
-      - name: Set up shell
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          rm.exe "C:/WINDOWS/system32/bash.EXE"
       - name: Check JVM
         shell: bash
         run: ./gradlew jvmTest
@@ -56,7 +80,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
-          ndk: 21.3.6528147
+          ndk: ${{ env.ANDROID_NDK_VERSION }}
           cmake: 3.10.2.4988404
           script: ./gradlew connectedCheck
       - name: Publish Linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up shell
         if: matrix.os == 'windows-latest'
         run: |
-          echo ::add-path::C:\msys64\usr\bin\
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           rm.exe "C:/WINDOWS/system32/bash.EXE"
       - name: Check JVM
         shell: bash

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -36,6 +36,35 @@ jobs:
           path: ~/.gradle
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
+      - name: Android environment
+        shell: bash
+        run: |
+          echo "ANDROID_HOME=$ANDROID_HOME" >> $GITHUB_ENV
+          echo "ANDROID_NDK_VERSION=21.3.6528147" >> $GITHUB_ENV
+      - name: Cached Android NDK
+        uses: actions/cache@v2
+        with:
+          path: ${{ format('{0}/ndk/{1}', env.ANDROID_HOME, env.ANDROID_NDK_VERSION) }}
+          key: ${{ runner.os }}-android-ndk-${{ env.ANDROID_NDK_VERSION }}
+      - name: Set up shell
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          rm.exe "C:/WINDOWS/system32/bash.EXE"
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Setup Android
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: |
+          $ANDROID_HOME/tools/bin/sdkmanager "ndk;$ANDROID_NDK_VERSION"
+      - name: Setup Android
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          $ANDROID_HOME\\tools\\bin\\sdkmanager.bat "ndk;$ANDROID_NDK_VERSION"
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
@@ -43,11 +72,6 @@ jobs:
       - name: Install Automake
         if: matrix.os == 'macOS-latest'
         run: brew install automake
-      - name: Set up shell
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          rm.exe "C:/WINDOWS/system32/bash.EXE"
       - name: Check JVM
         shell: bash
         run: ./gradlew jvmTest
@@ -64,7 +88,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
-          ndk: 21.3.6528147
+          ndk: ${{ env.ANDROID_NDK_VERSION }}
           cmake: 3.10.2.4988404
           script: ./gradlew connectedCheck
       - name: Publish Linux

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up shell
         if: matrix.os == 'windows-latest'
         run: |
-          echo ::add-path::C:\msys64\usr\bin\
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           rm.exe "C:/WINDOWS/system32/bash.EXE"
       - name: Check JVM
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,35 @@ jobs:
           path: ~/.gradle
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
+      - name: Android environment
+        shell: bash
+        run: |
+          echo "ANDROID_HOME=$ANDROID_HOME" >> $GITHUB_ENV
+          echo "ANDROID_NDK_VERSION=21.3.6528147" >> $GITHUB_ENV
+      - name: Cached Android NDK
+        uses: actions/cache@v2
+        with:
+          path: ${{ format('{0}/ndk/{1}', env.ANDROID_HOME, env.ANDROID_NDK_VERSION) }}
+          key: ${{ runner.os }}-android-ndk-${{ env.ANDROID_NDK_VERSION }}
+      - name: Set up shell
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          rm.exe "C:/WINDOWS/system32/bash.EXE"
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Setup Android
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: |
+          $ANDROID_HOME/tools/bin/sdkmanager "ndk;$ANDROID_NDK_VERSION"
+      - name: Setup Android
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          $ANDROID_HOME\\tools\\bin\\sdkmanager.bat "ndk;$ANDROID_NDK_VERSION"
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
@@ -49,11 +78,6 @@ jobs:
       - name: Install Automake
         if: matrix.os == 'macOS-latest'
         run: brew install automake
-      - name: Set up shell
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          rm.exe "C:/WINDOWS/system32/bash.EXE"
       - name: Check JVM
         shell: bash
         run: ./gradlew jvmTest
@@ -70,6 +94,6 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
-          ndk: 21.3.6528147
+          ndk: ${{ env.ANDROID_NDK_VERSION }}
           cmake: 3.10.2.4988404
           script: ./gradlew connectedCheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up shell
         if: matrix.os == 'windows-latest'
         run: |
-          echo ::add-path::C:\msys64\usr\bin\
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           rm.exe "C:/WINDOWS/system32/bash.EXE"
       - name: Check JVM
         shell: bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,24 +8,24 @@ import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
-    kotlin("multiplatform") version "1.4.0"
+    kotlin("multiplatform") version "1.4.31"
     `maven-publish`
 }
 
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:4.0.1")
+        classpath("com.android.tools.build:gradle:4.0.2")
     }
 }
 
 allprojects {
     group = "fr.acinq.secp256k1"
-    version = "0.4.1"
+    version = "0.5.0"
 
     repositories {
         jcenter()
@@ -66,7 +66,6 @@ kotlin {
 
     ios {
         secp256k1CInterop("ios")
-        // https://youtrack.jetbrains.com/issue/KT-39396
         compilations["main"].defaultSourceSet.dependsOn(nativeMain)
         // https://youtrack.jetbrains.com/issue/KT-39396
         compilations["main"].kotlinOptions.freeCompilerArgs += listOf("-include-binary", "$rootDir/native/build/ios/libsecp256k1.a")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -38,8 +38,8 @@ kotlin {
         }
         sourceSets["androidTest"].dependencies {
             implementation(kotlin("test-junit"))
-            implementation("androidx.test.ext:junit:1.1.1")
-            implementation("androidx.test.espresso:espresso-core:3.2.0")
+            implementation("androidx.test.ext:junit:1.1.2")
+            implementation("androidx.test.espresso:espresso-core:3.3.0")
         }
     }
 


### PR DESCRIPTION
Version 0.5.0

- Update to Kotlin 1.4.31
- Removed JCenter in favour of Maven Central.
- Updated Gradle to latest version.
- Updated Github CI to use the GITHUB_PATH environment file rather the add-path command (that was disabled for security reasons).