### PR TITLE
Clarify public key encoding and enrich tests

### DIFF
--- a/jni/c/src/fr_acinq_secp256k1_Secp256k1CFunctions.c
+++ b/jni/c/src/fr_acinq_secp256k1_Secp256k1CFunctions.c
@@ -72,7 +72,8 @@ JNIEXPORT jint JNICALL Java_fr_acinq_secp256k1_Secp256k1CFunctions_secp256k1_1ec
 
     if (jctx == 0) return 0;
     if (jseckey == NULL) return 0;
-    CHECKRESULT((*penv)->GetArrayLength(penv, jseckey) != 32, "secret key must be 32 bytes");
+    if ((*penv)->GetArrayLength(penv, jseckey) != 32) return 0;
+
     seckey = (*penv)->GetByteArrayElements(penv, jseckey, 0);
     result = secp256k1_ec_seckey_verify(ctx, (unsigned char*)seckey);
     (*penv)->ReleaseByteArrayElements(penv, jseckey, seckey, 0);

--- a/src/commonMain/kotlin/fr/acinq/secp256k1/Secp256k1.kt
+++ b/src/commonMain/kotlin/fr/acinq/secp256k1/Secp256k1.kt
@@ -52,11 +52,13 @@ public interface Secp256k1 {
 
     /**
      * Get the public key corresponding to the given private key.
+     * Returns the uncompressed public key (65 bytes).
      */
     public fun pubkeyCreate(privkey: ByteArray): ByteArray
 
     /**
      * Parse a serialized public key.
+     * Returns the uncompressed public key (65 bytes).
      */
     public fun pubkeyParse(pubkey: ByteArray): ByteArray
 
@@ -77,21 +79,25 @@ public interface Secp256k1 {
 
     /**
      * Negate the given public key.
+     * Returns the uncompressed public key (65 bytes).
      */
     public fun pubKeyNegate(pubkey: ByteArray): ByteArray
 
     /**
      * Tweak a public key by adding tweak times the generator to it.
+     * Returns the uncompressed public key (65 bytes).
      */
     public fun pubKeyTweakAdd(pubkey: ByteArray, tweak: ByteArray): ByteArray
 
     /**
      * Tweak a public key by multiplying it by a tweak value.
+     * Returns the uncompressed public key (65 bytes).
      */
     public fun pubKeyTweakMul(pubkey: ByteArray, tweak: ByteArray): ByteArray
 
     /**
      * Add a number of public keys together.
+     * Returns the uncompressed public key (65 bytes).
      */
     public fun pubKeyCombine(pubkeys: Array<ByteArray>): ByteArray
 
@@ -121,9 +127,9 @@ public interface Secp256k1 {
         return when {
             pubkey.size == 33 && (pubkey[0] == 2.toByte() || pubkey[0] == 3.toByte()) -> pubkey
             pubkey.size == 65 && pubkey[0] == 4.toByte() -> {
-                val pub1 = pubkey.copyOf(33)
-                pub1[0] = if (pubkey.last() % 2 == 0) 2.toByte() else 3.toByte()
-                pub1
+                val compressed = pubkey.copyOf(33)
+                compressed[0] = if (pubkey.last() % 2 == 0) 2.toByte() else 3.toByte()
+                compressed
             }
             else -> throw Secp256k1Exception("invalid public key")
         }

--- a/src/nativeMain/kotlin/fr/acinq/secp256k1/Secp256k1Native.kt
+++ b/src/nativeMain/kotlin/fr/acinq/secp256k1/Secp256k1Native.kt
@@ -88,7 +88,7 @@ public object Secp256k1Native : Secp256k1 {
     }
 
     public override fun secKeyVerify(privkey: ByteArray): Boolean {
-        require(privkey.size == 32)
+        if (privkey.size != 32) return false
         memScoped {
             val nPrivkey = toNat(privkey)
             return secp256k1_ec_seckey_verify(ctx, nPrivkey) == 1

--- a/tests/src/commonTest/kotlin/fr/acinq/secp256k1/Secp256k1Test.kt
+++ b/tests/src/commonTest/kotlin/fr/acinq/secp256k1/Secp256k1Test.kt
@@ -13,7 +13,9 @@ class Secp256k1Test {
 
     @Test
     fun verifyInvalidPrivateKey() {
-        val greaterThanCurveOrder = Hex.decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".lowercase())
+        val invalidSize = Hex.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A106353001")
+        assertFalse(Secp256k1.secKeyVerify(invalidSize))
+        val greaterThanCurveOrder = Hex.decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141".lowercase())
         assertFalse(Secp256k1.secKeyVerify(greaterThanCurveOrder))
         val zero = Hex.decode("0000000000000000000000000000000000000000000000000000000000000000".lowercase())
         assertFalse(Secp256k1.secKeyVerify(zero))


### PR DESCRIPTION
This PR contains two independent commits.

In the first one, we make `seckeyVerify` more consistent: we were previously throwing in some cases and return a boolean in others, now we're returning a boolean in all cases.

In the second one, we explicitly document that public keys are returned in uncompressed form.
We add tests to verify that and avoid future regressions.
We also enrich the signature normalization tests and public/private key validity tests.