### PR TITLE
Update secp256k1 sources

### DIFF
--- a/jni/c/src/fr_acinq_secp256k1_Secp256k1CFunctions.c
+++ b/jni/c/src/fr_acinq_secp256k1_Secp256k1CFunctions.c
@@ -307,9 +307,9 @@ JNIEXPORT jbyteArray JNICALL Java_fr_acinq_secp256k1_Secp256k1CFunctions_secp256
     if (jseckey == NULL) return 0;
     CHECKRESULT((*penv)->GetArrayLength(penv, jseckey) != 32, "secret key must be 32 bytes");
     seckey = (*penv)->GetByteArrayElements(penv, jseckey, 0);
-    result = secp256k1_ec_privkey_negate(ctx, (unsigned char*)seckey);
+    result = secp256k1_ec_seckey_negate(ctx, (unsigned char*)seckey);
     (*penv)->ReleaseByteArrayElements(penv, jseckey, seckey, 0);
-    CHECKRESULT(!result, "secp256k1_ec_privkey_negate failed");
+    CHECKRESULT(!result, "secp256k1_ec_seckey_negate failed");
     return jseckey;
 }
 
@@ -369,10 +369,10 @@ JNIEXPORT jbyteArray JNICALL Java_fr_acinq_secp256k1_Secp256k1CFunctions_secp256
     CHECKRESULT((*penv)->GetArrayLength(penv, jtweak) != 32, "tweak must be 32 bytes");
     seckey = (*penv)->GetByteArrayElements(penv, jseckey, 0);
     tweak = (*penv)->GetByteArrayElements(penv, jtweak, 0);
-    result = secp256k1_ec_privkey_tweak_add(ctx, (unsigned char*)seckey, (unsigned char*)tweak);
+    result = secp256k1_ec_seckey_tweak_add(ctx, (unsigned char*)seckey, (unsigned char*)tweak);
     (*penv)->ReleaseByteArrayElements(penv, jseckey, seckey, 0);
     (*penv)->ReleaseByteArrayElements(penv, jtweak, tweak, 0);
-    CHECKRESULT(!result, "secp256k1_ec_privkey_tweak_add failed");
+    CHECKRESULT(!result, "secp256k1_ec_seckey_tweak_add failed");
     return jseckey;
 }
 
@@ -437,8 +437,8 @@ JNIEXPORT jbyteArray JNICALL Java_fr_acinq_secp256k1_Secp256k1CFunctions_secp256
     CHECKRESULT((*penv)->GetArrayLength(penv, jtweak) != 32, "tweak must be 32 bytes");
     seckey = (*penv)->GetByteArrayElements(penv, jseckey, 0);
     tweak = (*penv)->GetByteArrayElements(penv, jtweak, 0);
-    result = secp256k1_ec_privkey_tweak_mul(ctx, (unsigned char*)seckey, (unsigned char*)tweak);
-    CHECKRESULT(!result, "secp256k1_ec_privkey_tweak_mul failed");
+    result = secp256k1_ec_seckey_tweak_mul(ctx, (unsigned char*)seckey, (unsigned char*)tweak);
+    CHECKRESULT(!result, "secp256k1_ec_seckey_tweak_mul failed");
     (*penv)->ReleaseByteArrayElements(penv, jseckey, seckey, 0);
     (*penv)->ReleaseByteArrayElements(penv, jtweak, tweak, 0);
     return jseckey;
@@ -702,7 +702,7 @@ JNIEXPORT jbyteArray JNICALL Java_fr_acinq_secp256k1_Secp256k1CFunctions_secp256
         auxrand32 = (*penv)->GetByteArrayElements(penv, jauxrand32, 0);
     }
 
-    result = secp256k1_schnorrsig_sign(ctx, signature, (unsigned char*)msg, &keypair, auxrand32);
+    result = secp256k1_schnorrsig_sign32(ctx, signature, (unsigned char*)msg, &keypair, auxrand32);
     (*penv)->ReleaseByteArrayElements(penv, jmsg, msg, 0);
     if (auxrand32 != 0) {
         (*penv)->ReleaseByteArrayElements(penv, jauxrand32, auxrand32, 0);

--- a/src/nativeMain/kotlin/fr/acinq/secp256k1/Secp256k1Native.kt
+++ b/src/nativeMain/kotlin/fr/acinq/secp256k1/Secp256k1Native.kt
@@ -118,7 +118,7 @@ public object Secp256k1Native : Secp256k1 {
         memScoped {
             val negated = privkey.copyOf()
             val negPriv = toNat(negated)
-            secp256k1_ec_privkey_negate(ctx, negPriv).requireSuccess("secp256k1_ec_privkey_negate() failed")
+            secp256k1_ec_seckey_negate(ctx, negPriv).requireSuccess("secp256k1_ec_seckey_negate() failed")
             return negated
         }
     }
@@ -129,7 +129,7 @@ public object Secp256k1Native : Secp256k1 {
             val added = privkey.copyOf()
             val natAdd = toNat(added)
             val natTweak = toNat(tweak)
-            secp256k1_ec_privkey_tweak_add(ctx, natAdd, natTweak).requireSuccess("secp256k1_ec_privkey_tweak_add() failed")
+            secp256k1_ec_seckey_tweak_add(ctx, natAdd, natTweak).requireSuccess("secp256k1_ec_seckey_tweak_add() failed")
             return added
         }
     }
@@ -247,7 +247,7 @@ public object Secp256k1Native : Secp256k1 {
             val nSig = allocArray<UByteVar>(64)
             val keypair = alloc<secp256k1_keypair>()
             secp256k1_keypair_create(ctx, keypair.ptr, nSec).requireSuccess("secp256k1_keypair_create() failed")
-            secp256k1_schnorrsig_sign(ctx, nSig, nData, keypair.ptr, nAuxrand32).requireSuccess("secp256k1_ecdsa_sign() failed")
+            secp256k1_schnorrsig_sign32(ctx, nSig, nData, keypair.ptr, nAuxrand32).requireSuccess("secp256k1_ecdsa_sign() failed")
             return nSig.readBytes(64)
         }
     }


### PR DESCRIPTION
We're now at 8746600eec5e7fcd35dabd480839a3a4bdfee87b, same as bitcoin core at 747cdf1d652d8587e9f2e3d4436c3ecdbf56d0a5