### PR TITLE
Fix artifact names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(kotlin("stdlib-common"))
-                implementation(kotlin("fr.acinq.secp256k1:secp256k1:$secp256k1_version"))
+                implementation(kotlin("fr.acinq.secp256k1:secp256k1-kmp:$secp256k1_version"))
             }
         }
         val jvmMain by getting {
             dependencies {
                 implementation(kotlin("stdlib"))
-                implementation(kotlin("fr.acinq.secp256k1:secp256k1-jni-jvm:$secp256k1_version"))
+                implementation(kotlin("fr.acinq.secp256k1:secp256k1-kmp-jni-jvm:$secp256k1_version"))
             }
         }
         val androidMain by getting {
             dependencies {
                 implementation(kotlin("stdlib"))
-                implementation(kotlin("fr.acinq.secp256k1:secp256k1-jni-android:$secp256k1_version"))
+                implementation(kotlin("fr.acinq.secp256k1:secp256k1-kmp-jni-android:$secp256k1_version"))
             }
         }
     }
@@ -65,15 +65,15 @@ JNI libraries are included for:
 Along this library, you **must** specify which JNI native library to use in your dependency manager:
 
 * **For desktop or server JVMs**, you must add the dependency:
-  * Either the `fr.acinq.secp256k1:secp256k1-jni-jvm` dependency which imports all supported platforms.
+  * Either the `fr.acinq.secp256k1:secp256k1-kmp-jni-jvm` dependency which imports all supported platforms.
   * Or the platform specific dependencies (note that you can add multiple as they do not conflict):
-    * `fr.acinq.secp256k1:secp256k1-jni-jvm-linux` for Linux
-    * `fr.acinq.secp256k1:secp256k1-jni-jvm-darwin` for Mac OS X
-    * `fr.acinq.secp256k1:secp256k1-jni-jvm-mingw` for Windows
-* **For Android**, you must add the `fr.acinq.secp256k1:secp256k1-jni-android` dependency
+    * `fr.acinq.secp256k1:secp256k1-kmp-jni-jvm-linux` for Linux
+    * `fr.acinq.secp256k1:secp256k1-kmp-jni-jvm-darwin` for Mac OS X
+    * `fr.acinq.secp256k1:secp256k1-kmp-jni-jvm-mingw` for Windows
+* **For Android**, you must add the `fr.acinq.secp256k1:secp256k1-kmp-jni-android` dependency
 
 If you are using the JVM on an OS for which we don't provide JNI bindings (32 bits OS for example), you can use your own library native library by
-adding the `fr.acinq.secp256k1:secp256k1-jni-jvm` dependency and specifying its path with `-Dfr.acinq.secp256k1.lib.path` and optionally its name with `-Dfr.acinq.secp256k1.lib.name`
+adding the `fr.acinq.secp256k1:secp256k1-kmp-jni-jvm` dependency and specifying its path with `-Dfr.acinq.secp256k1.lib.path` and optionally its name with `-Dfr.acinq.secp256k1.lib.name`
 (if unspecified bitcoink use the standard name for your OS i.e. libsecp256k1.so on Linux, secp256k1.dll on Windows, ...).
 
 To compile your own JNI bindings, have a look add the `native/build.sh` and `jni/build.sh` scripts.


### PR DESCRIPTION
Hi there! I was playing around with the library earlier this week and after getting some Gradle errors I noticed that the readme had incorrect artifact names in the section about adding dependencies (for example `fr.acinq.secp256k1:secp256k1-jni-jvm`  does not resolve because the `kmp` part of the artifact is missing.

Let me know if I correctly fixed the readme or if I forgot anything in there.

P.S. Thanks for the awesome library!