### PR TITLE
Darwin ARM64 publishing script

### DIFF
--- a/native/build.sh
+++ b/native/build.sh
@@ -16,7 +16,7 @@ if [ "$TARGET" == "mingw" ]; then
 elif [ "$TARGET" == "linux" ]; then
   CONF_OPTS="CFLAGS=-fPIC"
 elif [ "$TARGET" == "darwin" ]; then
-  CONF_OPTS="--host=x86_64-w64-darwin"
+  CONF_OPTS=""
 else
   echo "Unknown TARGET=$TARGET"
   exit 1

--- a/publishing/PUBLISHING.md
+++ b/publishing/PUBLISHING.md
@@ -27,16 +27,62 @@ You must edit `secp256k1-kmp-staging-upload.sh` and add your sonatype credential
 ## Adding custom JNI bindings
 
 Github CI currently generates JNI bindings for Windows x64, Linux x64 and iOS x64. But it is possible to add custom bindings to JNI packages before 
-they are published to maven central. This is how we add linux arm64 bindings:
-- compile JNI bindings for Linux Arm64 (on a Linux Arm64 machine, cross-compilation is not supported)
-  - git clone --recursive https://github.com/ACINQ/secp256k1-kmp.git
-  - cd secp256k1-kmp 
-  - TARGET=linux ./native/build.sh 
-  - mkdir -p jni/jvm/build/linux 
-  - TARGET=linux ./jni/jvm/build.sh 
-  - JNI library is: jni/jvm/build/linux/libsecp256k1-jni.so
-- copy libsecp256k1-jni.so to fr/acinq/secp256k1/jni/native/linux-aarch64/libsecp256k1-jni.so
-- run `secp256k1-kmp-add-linuxarm64.sh` and specify either `release` or `snapshot` and the `VERSION` environment variable, for example:
-  - VERSION=0.6.4-SNAPSHOT ./secp256k1-kmp-add-linuxarm64.sh snapshot
-  - VERSION=0.6.3 ./secp256k1-kmp-add-linuxarm64.sh release
+they are published to maven central.
 
+This is how we add Linux arm64 bindings:
+- compile JNI bindings for Linux Arm64 (on a Linux Arm64 machine, cross-compilation is not supported)
+  ```bash 
+  git clone --recursive https://github.com/ACINQ/secp256k1-kmp.git
+  
+  cd secp256k1-kmp 
+  
+  TARGET=linux ./native/build.sh 
+  
+  mkdir -p jni/jvm/build/linux 
+  
+  TARGET=linux ./jni/jvm/build.sh
+  ```
+- JNI library is: jni/jvm/build/linux/libsecp256k1-jni.so
+- copy libsecp256k1-jni.so to fr/acinq/secp256k1/jni/native/linux-aarch64/libsecp256k1-jni.so
+  ```bash
+  cd publishing
+  
+  mkdir -p fr/acinq/secp256k1/jni/native/linux-aarch64
+  
+  cp ../jni/jvm/build/linux/libsecp256k1-jni.so fr/acinq/secp256k1/jni/native/linux-aarch64
+  ```
+- run `secp256k1-kmp-add-linuxarm64.sh` and specify either `release` or `snapshot` and the `VERSION` environment variable, for example:
+  ```bash
+  VERSION=0.6.4-SNAPSHOT ./secp256k1-kmp-add-linuxarm64.sh snapshot
+  
+  VERSION=0.6.3 ./secp256k1-kmp-add-linuxarm64.sh release
+  ```
+
+This is how we add Mac OS X arm64 bindings:
+- compile JNI bindings for Mac OS X arm64 (on a Mac OS X arm64 machine, cross-compilation is not supported)
+  ```bash 
+  git clone --recursive https://github.com/ACINQ/secp256k1-kmp.git
+  
+  cd secp256k1-kmp 
+  
+  TARGET=darwin ./native/build.sh 
+  
+  mkdir -p jni/jvm/build/darwin 
+  
+  TARGET=darwin ./jni/jvm/build.sh
+  ```
+- JNI library is: jni/jvm/build/darwin/libsecp256k1-jni.dylib
+- copy libsecp256k1-jni.dylib to fr/acinq/secp256k1/jni/native/darwin-aarch64/libsecp256k1-jni.dylib
+  ```bash
+  cd publishing
+  
+  mkdir -p fr/acinq/secp256k1/jni/native/darwin-aarch64
+  
+  cp ../jni/jvm/build/darwin/libsecp256k1-jni.dylib fr/acinq/secp256k1/jni/native/darwin-aarch64
+  ```
+- run `secp256k1-kmp-add-darwinarm64.sh` and specify either `release` or `snapshot` and the `VERSION` environment variable, for example:
+  ```bash
+  VERSION=0.6.4-SNAPSHOT ./secp256k1-kmp-add-darwinarm64.sh snapshot
+  
+  VERSION=0.6.3 ./secp256k1-kmp-add-darwinarm64.sh release
+  ```

--- a/publishing/PUBLISHING.md
+++ b/publishing/PUBLISHING.md
@@ -82,7 +82,22 @@ This is how we add Mac OS X arm64 bindings:
   ```
 - run `secp256k1-kmp-add-darwinarm64.sh` and specify either `release` or `snapshot` and the `VERSION` environment variable, for example:
   ```bash
-  VERSION=0.6.4-SNAPSHOT ./secp256k1-kmp-add-darwinarm64.sh snapshot
+  VERSION=0.7.1-SNAPSHOT ./secp256k1-kmp-add-darwinarm64.sh snapshot
   
-  VERSION=0.6.3 ./secp256k1-kmp-add-darwinarm64.sh release
+  VERSION=0.7.0 ./secp256k1-kmp-add-darwinarm64.sh release
   ```
+
+This is how to install the updated JAR-file to your local maven repository:
+
+```bash
+export TARGET=darwin
+
+export VERSION=0.7.0
+
+mvn install:install-file \
+    -Dfile=secp256k1-kmp-jni-jvm-$TARGET-$VERSION.jar \
+    -DgroupId=fr.acinq.secp256k1 \
+    -DartifactId=secp256k1-kmp-jni-jvm-$TARGET \
+    -Dversion=$VERSION \
+    -Dpackaging=jar
+```

--- a/publishing/secp256k1-kmp-add-darwinarm64.sh
+++ b/publishing/secp256k1-kmp-add-darwinarm64.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -x
+
+if [ $# -eq 0 ]
+  then
+    echo "specify either snapshot or release"
+    exit 1
+fi
+
+DYLIB=fr/acinq/secp256k1/jni/native/darwin-aarch64/libsecp256k1-jni.dylib
+
+# add aarch64 (ARM64) library to the darwin jar
+if [ -e $DYLIB ]
+then
+    file $DYLIB | grep arm64
+    if [ $? -eq 0 ]
+    then
+      jar -uf $1/fr/acinq/secp256k1/secp256k1-kmp-jni-jvm-darwin/$VERSION/secp256k1-kmp-jni-jvm-darwin-$VERSION.jar fr || exit
+    else
+      echo "libsecp256k1-jni.dylib is built for a different architecture"
+      file $DYLIB
+      exit 2
+    fi
+else
+    echo "libsecp256k1-jni.dylib for darwin-arch64 is missing"
+    exit 1
+fi


### PR DESCRIPTION
I didn't find how to set up a cross build for Mac OS X, so I added a script similar to `secp256k1-kmp-add-linuxarm64.sh`.