### PR TITLE
Build a universal JNI binary for macos

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ buildscript {
 
 allprojects {
     group = "fr.acinq.secp256k1"
-    version = "0.15.0"
+    version = "0.16.0-SNAPSHOT"
 
     repositories {
         google()

--- a/jni/jvm/build.sh
+++ b/jni/jvm/build.sh
@@ -17,6 +17,7 @@ if [ "$TARGET" == "linux" ]; then
   CC_OPTS="-fPIC"
 elif [ "$TARGET" == "darwin" ]; then
   OUTFILE=libsecp256k1-jni.dylib
+  CC_OPTS="-arch arm64 -arch x86_64"
 elif [ "$TARGET" == "mingw" ]; then
   OUTFILE=secp256k1-jni.dll
   CC=x86_64-w64-mingw32-gcc

--- a/jni/jvm/darwin/build.gradle.kts
+++ b/jni/jvm/darwin/build.gradle.kts
@@ -12,12 +12,8 @@ dependencies {
 val copyJni by tasks.creating(Sync::class) {
     onlyIf { org.gradle.internal.os.OperatingSystem.current().isMacOsX }
     dependsOn(":jni:jvm:buildNativeHost")
-    val arch = when (System.getProperty("os.arch")) {
-        "aarch64" -> "aarch64"
-        else -> "x86_64"
-    }
     from(rootDir.resolve("jni/jvm/build/darwin/libsecp256k1-jni.dylib"))
-    into(buildDir.resolve("jniResources/fr/acinq/secp256k1/jni/native/darwin-$arch"))
+    into(buildDir.resolve("jniResources/fr/acinq/secp256k1/jni/native/darwin"))
 }
 
 (tasks["processResources"] as ProcessResources).apply {

--- a/jni/jvm/src/main/kotlin/fr/acinq/secp256k1/jni/OSInfo.kt
+++ b/jni/jvm/src/main/kotlin/fr/acinq/secp256k1/jni/OSInfo.kt
@@ -19,7 +19,8 @@ internal object OSInfo {
    private const val PPC = "ppc"
    private const val PPC64 = "ppc64"
 
-   @JvmStatic val nativeSuffix: String get() = "$os-$arch"
+    // on macos we build a universal library that contains arm64 and x64 binaries
+   @JvmStatic val nativeSuffix: String get() = if (os == "darwin") os else "$os-$arch"
 
    @JvmStatic val os: String get() = translateOSName(System.getProperty("os.name"))
 

--- a/native/build.sh
+++ b/native/build.sh
@@ -12,22 +12,20 @@ cd "$(dirname "$0")"
 cd secp256k1
 
 if [ "$TARGET" == "mingw" ]; then
-  CONF_OPTS="CFLAGS=-fPIC --host=x86_64-w64-mingw32"
+  CFLAGS="-fPIC"
+  CONF_OPTS=" --host=x86_64-w64-mingw32"
 elif [ "$TARGET" == "linux" ]; then
-  CONF_OPTS="CFLAGS=-fPIC"
+  CFLAGS="-fPIC"
 elif [ "$TARGET" == "darwin" ]; then
-  CONF_OPTS=""
+  CFLAGS="-arch arm64 -arch x86_64"
+  LDFLAGS="-arch arm64 -arch x86_64"
 else
   echo "Unknown TARGET=$TARGET"
   exit 1
 fi
 
 ./autogen.sh
-if [ "$TARGET" == "darwin" ]; then
-  CFLAGS="-arch arm64 -arch x86_64" ./configure $CONF_OPTS --enable-experimental --enable-module_ecdh --enable-module-recovery --enable-module-schnorrsig --enable-module-musig --enable-benchmark=no --enable-shared=no --enable-exhaustive-tests=no --enable-tests=no
-else
-  ./configure $CONF_OPTS --enable-experimental --enable-module_ecdh --enable-module-recovery --enable-module-schnorrsig --enable-module-musig --enable-benchmark=no --enable-shared=no --enable-exhaustive-tests=no --enable-tests=no
-fi
+CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" ./configure $CONF_OPTS --enable-experimental --enable-module_ecdh --enable-module-recovery --enable-module-schnorrsig --enable-module-musig --enable-benchmark=no --enable-shared=no --enable-exhaustive-tests=no --enable-tests=no
 make clean
 make
 


### PR DESCRIPTION
Universal libraries embed both arm64 and x64 binaries, and are built on our CI.
 This makes our build and release process simpler, as we no longer need to build macos arm64 JNI libs "manually" on a mac M1/M2. 