### PR TITLE
Fix CI release script 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
 
 jobs:
+
   upload:
     name: Upload
     runs-on: ${{ matrix.os }}
@@ -13,7 +14,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - name: Check out
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
       - name: Enable KVM
@@ -22,6 +23,9 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+      - name: Install cross compiler
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
       - name: Cached Konan
         uses: actions/cache@v4
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ buildscript {
 
 allprojects {
     group = "fr.acinq.secp256k1"
-    version = "0.17.2"
+    version = "0.17.3"
 
     repositories {
         google()


### PR DESCRIPTION
Cross-compiler needed to build arm64 binaries was missing from `release.yml`, this was not detected because we cannot run tests for arm64 targets ....