### PR TITLE
Update build and publishing scripts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,11 @@ kotlin {
         }
     }
 
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     fun KotlinNativeTarget.secp256k1CInterop(target: String) {
         compilations["main"].cinterops {
             val libsecp256k1 by creating {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.util.*
 
 plugins {
-    kotlin("multiplatform") version "2.1.10"
+    kotlin("multiplatform") version "2.1.21"
     id("org.jetbrains.dokka") version "1.9.20"
     `maven-publish`
 }
@@ -23,7 +23,7 @@ buildscript {
 
 allprojects {
     group = "fr.acinq.secp256k1"
-    version = "0.17.3"
+    version = "0.18.0"
 
     repositories {
         google()

--- a/jni/jvm/build.gradle.kts
+++ b/jni/jvm/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 publishing {

--- a/jni/jvm/darwin/build.gradle.kts
+++ b/jni/jvm/darwin/build.gradle.kts
@@ -1,8 +1,21 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     kotlin("jvm")
     `java-library`
     id("org.jetbrains.dokka")
     `maven-publish`
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {

--- a/jni/jvm/linux/build.gradle.kts
+++ b/jni/jvm/linux/build.gradle.kts
@@ -1,7 +1,20 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     kotlin("jvm")
     id("org.jetbrains.dokka")
     `maven-publish`
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {

--- a/publishing/secp256k1-kmp-staging-upload.sh
+++ b/publishing/secp256k1-kmp-staging-upload.sh
@@ -1,21 +1,23 @@
 #!/bin/bash -x
 #
-# first you must sign all files:
-# find release -type f -print -exec gpg -ab {} \;
+# usage:
+# VERSION=XXX ./secp256k1-kmp-staging-upload.sh create # to create bundles, which include checksums and signatures (requires access to a valid gpg key)
+# VERSION=XXX ./secp256k1-kmp-staging-upload.sh upload # to upload bundles to sonatype's staging area (requires a valid portal token)
 
 if [[ -z "${VERSION}" ]]; then
   echo "VERSION is not defined"
   exit 1
 fi
 
-if [[ -z "${OSS_USER}" ]]; then
-  echo "OSS_USER is not defined"
+if [[ -z "${CENTRAL_TOKEN_GPG_FILE}" ]]; then
+  echo "CENTRAL_TOKEN_GPG_FILE is not defined"
   exit 1
 fi
 
-read -p "Password : " -s OSS_PASSWORD
+CENTRAL_TOKEN=$(gpg --decrypt $CENTRAL_TOKEN_GPG_FILE)
 
-
+pushd .
+cd release
 for i in 	secp256k1-kmp \
 		secp256k1-kmp-iosarm64 \
 		secp256k1-kmp-iossimulatorarm64 \
@@ -33,12 +35,21 @@ for i in 	secp256k1-kmp \
 		secp256k1-kmp-macosarm64 \
 		secp256k1-kmp-macosx64
 do
-	pushd .
-	cd release/fr/acinq/secp256k1/$i/$VERSION
-	pwd
-	jar -cvf bundle.jar *
-	# use correct sonatype credentials here
-  curl -v -XPOST -u $OSS_USER:$OSS_PASSWORD --upload-file bundle.jar https://oss.sonatype.org/service/local/staging/bundle_upload
-  popd
+	DIR=fr/acinq/secp256k1/$i/$VERSION
+	echo DIR is $DIR
+	case $1 in
+	create)
+  	for file in $DIR/*
+	  do
+	    sha1sum $file | sed 's/ .*//' > $file.sha1
+	    md5sum $file | sed 's/ .*//' > $file.md5
+	    gpg -ab $file
+    done
+	  zip -r $i.zip $DIR
+	  ;;
+	upload)
+    curl --request POST --verbose --header "Authorization: Bearer ${CENTRAL_TOKEN}" --form bundle=@$i.zip https://central.sonatype.com/api/v1/publisher/upload
+    ;;
+  esac
 done
-
+popd

--- a/publishing/secp256k1-kmp-staging-upload.sh
+++ b/publishing/secp256k1-kmp-staging-upload.sh
@@ -36,7 +36,6 @@ for i in 	secp256k1-kmp \
 		secp256k1-kmp-macosx64
 do
 	DIR=fr/acinq/secp256k1/$i/$VERSION
-	echo DIR is $DIR
 	case $1 in
 	create)
   	for file in $DIR/*


### PR DESCRIPTION
We update our build to target kotlin 2.1.21 (same as lightning-kmp), and our publishing scripts to migrate from Sonatype's OSSRH (which is being shutdown) to Sonatype's Portal Publisher API (see https://central.sonatype.org/publish/publish-portal-api/). 
There are no functional changes.